### PR TITLE
fix: revert lastest commit on x265 fixing CMAKE errors when compiling on aarch64

### DIFF
--- a/fetch
+++ b/fetch
@@ -193,6 +193,7 @@ fetch_x265() {
   local url="https://bitbucket.org/multicoreware/x265_git.git"
   rm -rf src/x265_git
   git -C src clone --single-branch "${url}"
+  git -C src/x265_git revert --no-commit b354c009a60bcd6d7fc04014e200a1ee9c45c167
 }
 
 if [[ $# == 0 ]]; then


### PR DESCRIPTION
Temporary fix until x265/CMake resolve upstream

Reverts x265 commit b354c009[^1] that prematurely adopted CMake 4.0-RC5
- CMake 4.0 isn't officially released yet
- New CMake commit broke aarch64 build for x265[^2]
- Single revert commit applied post-clone in the fetch script

Tested: M4 Pro (macOS 24D81)

---
[^1]: https://bitbucket.org/multicoreware/x265_git/commits/b354c009a60bcd6d7fc04014e200a1ee9c45c167
[^2]: Though potentially those errors were thrown because somehow ninja couldn't find compiler from XCode?
